### PR TITLE
Fix explore sorting and algolia search modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,6 +291,19 @@
         .close-button:hover {
             background: rgba(255, 255, 255, 0.2);
         }
+        .search-results-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .search-results-list li {
+            padding: 8px 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            cursor: pointer;
+        }
+        .search-results-list li:hover {
+            background: rgba(255, 255, 255, 0.1);
+        }
         /* ... other existing modal styles (.video-container, .song-title, etc.) ... */
         .video-container {
             position: relative;
@@ -444,6 +457,15 @@
             <p class="song-description"></p>
             <div class="attributes-grid"></div>
             <div class="external-links"></div>
+        </div>
+    </div>
+
+    <!-- Search Results Modal -->
+    <div id="searchModal" class="modal">
+        <div class="modal-content">
+            <button class="close-button">&times;</button>
+            <h2 class="search-results-title"></h2>
+            <ul class="search-results-list"></ul>
         </div>
     </div>
 

--- a/src/ui/search.js
+++ b/src/ui/search.js
@@ -1,4 +1,4 @@
-export function initSearchBar(inputEl, algoliaIndex, onSelect) {
+export function initSearchBar(inputEl, algoliaIndex, onSelect, onSearch) {
   const container = document.createElement('div');
   container.className = 'search-results';
   inputEl.parentNode.style.position = 'relative';
@@ -32,8 +32,15 @@ export function initSearchBar(inputEl, algoliaIndex, onSelect) {
 
   inputEl.addEventListener('keydown', e => {
     if (e.key === 'Enter') {
-      const first = container.querySelector('.search-result');
-      if (first) first.click();
+      e.preventDefault();
+      const q = inputEl.value.trim();
+      container.innerHTML = '';
+      if (onSearch) {
+        onSearch(q);
+      } else {
+        const first = container.querySelector('.search-result');
+        if (first) first.click();
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- sort explore filter values by count then name
- extend search bar to open new Algolia results modal
- add modal markup and styles for search results

## Testing
- `npm test` *(fails: Missing script)*