### PR TITLE
Add persistent bottom player

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,16 @@
         /* .controls-bar{transition:opacity 0.2s ease;} */
         .material-icons{font-size:24px;}
 
+        /* Bottom Player Styles */
+        .bottom-player{position:fixed;bottom:0;left:0;width:100%;background:#111;border-top:1px solid rgba(255,255,255,0.1);display:flex;align-items:center;padding:8px;box-sizing:border-box;z-index:3000;}
+        .bottom-player.hidden{display:none;}
+        .bottom-player .player-video{width:200px;height:112px;position:relative;flex-shrink:0;}
+        .bottom-player .player-video iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
+        .bottom-player .player-info{display:flex;align-items:center;flex:1;margin-left:10px;overflow:hidden;}
+        .bottom-player .player-title{flex:1;margin-right:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+        .bottom-player .player-controls{display:flex;align-items:center;gap:6px;}
+        #player-volume{width:100px;}
+
     </style>
 </head>
 <body>
@@ -469,6 +479,21 @@
         </div>
     </div>
 
+    <!-- Persistent Bottom Player -->
+    <div id="bottom-player" class="bottom-player hidden">
+        <div class="player-video"></div>
+        <div class="player-info">
+            <span class="player-title"></span>
+            <div class="player-controls">
+                <button id="player-prev" class="icon-button" title="Previous"><span class="material-icons">skip_previous</span></button>
+                <button id="player-play" class="icon-button" title="Play/Pause"><span class="material-icons">pause</span></button>
+                <button id="player-next" class="icon-button" title="Next"><span class="material-icons">skip_next</span></button>
+                <input id="player-volume" type="range" min="0" max="100" value="100" />
+            </div>
+        </div>
+    </div>
+
+    <script src="https://www.youtube.com/iframe_api"></script>
     <script type="module" src="src/index.js"></script>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import * as etherscanApi from './api/etherscan.js';
     const ALLOWED_MARKETPLACES = ['opensea', 'blur'];
     let collectionSlug = null; // To store the fetched OpenSea collection slug
     let etherscanCollectorsCache = null; // cache collectors data
+    const TOTAL_SONGS = 5852;
     console.log('OpenSea ENV Vars:', { key: OPENSEA_API_KEY ? 'Loaded' : 'MISSING', contract: OPENSEA_CONTRACT_ADDRESS ? 'Loaded' : 'MISSING' });
 
     // In-memory cache for cheapest listings so we only fetch once per session
@@ -475,6 +476,18 @@ import * as etherscanApi from './api/etherscan.js';
     const modal = document.getElementById('songModal');
     const closeButton = modal.querySelector('.close-button');
 
+    // Bottom player elements
+    const bottomPlayer = document.getElementById('bottom-player');
+    const bottomVideoContainer = bottomPlayer.querySelector('.player-video');
+    const bottomTitleEl = bottomPlayer.querySelector('.player-title');
+    const prevBtn = document.getElementById('player-prev');
+    const playBtn = document.getElementById('player-play');
+    const nextBtn = document.getElementById('player-next');
+    const volumeInput = document.getElementById('player-volume');
+    let currentPlayingId = null;
+    let currentIframe = null;
+    let isPlaying = false;
+
     // Left Sidebar (for OpenSea data)
     const leftSidebar = document.getElementById('left-sidebar');
     const leftSidebarTitle = leftSidebar.querySelector('.left-sidebar-title');
@@ -489,9 +502,18 @@ import * as etherscanApi from './api/etherscan.js';
     const searchInput = document.getElementById('search-input');
     const forSaleCountSpan = document.getElementById('for-sale-count');
 
-    closeButton.addEventListener('click', () => (modal.style.display = 'none'));
+    function closeSongModal() {
+        modal.style.display = 'none';
+        if (currentIframe && currentIframe.parentElement) {
+            bottomVideoContainer.innerHTML = '';
+            bottomVideoContainer.appendChild(currentIframe);
+            bottomPlayer.classList.remove('hidden');
+        }
+    }
+
+    closeButton.addEventListener('click', () => closeSongModal());
     modal.addEventListener('click', e => {
-        if (e.target === modal) modal.style.display = 'none';
+        if (e.target === modal) closeSongModal();
     });
 
     if (homeViewBtn) {
@@ -505,6 +527,66 @@ import * as etherscanApi from './api/etherscan.js';
             id => displaySongDetails(id),
             q => openSearchResults(q)
         );
+    }
+
+    function sendPlayerCommand(func, args = []) {
+        if (!currentIframe) return;
+        currentIframe.contentWindow.postMessage(JSON.stringify({ event: 'command', func, args }), '*');
+    }
+
+    playBtn.addEventListener('click', () => {
+        if (!currentIframe) return;
+        if (isPlaying) {
+            sendPlayerCommand('pauseVideo');
+            isPlaying = false;
+            playBtn.querySelector('.material-icons').textContent = 'play_arrow';
+        } else {
+            sendPlayerCommand('playVideo');
+            isPlaying = true;
+            playBtn.querySelector('.material-icons').textContent = 'pause';
+            bottomPlayer.classList.remove('hidden');
+        }
+    });
+
+    volumeInput.addEventListener('input', () => {
+        const vol = parseInt(volumeInput.value, 10);
+        sendPlayerCommand('setVolume', [vol]);
+    });
+
+    prevBtn.addEventListener('click', () => {
+        if (currentPlayingId && currentPlayingId > 1) {
+            loadSongById(currentPlayingId - 1);
+        }
+    });
+
+    nextBtn.addEventListener('click', () => {
+        if (currentPlayingId && currentPlayingId < TOTAL_SONGS) {
+            loadSongById(currentPlayingId + 1);
+        }
+    });
+
+    async function loadSongById(id) {
+        try {
+            const song = await algoliaIndex.getObject(id.toString());
+            if (!song || !song.youtube_url) return;
+            const vid = getYouTubeVideoId(song.youtube_url);
+            if (!vid) return;
+            if (!currentIframe) {
+                currentIframe = document.createElement('iframe');
+                currentIframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+                currentIframe.allowFullscreen = true;
+            }
+            currentIframe.src = `https://www.youtube.com/embed/${vid}?enablejsapi=1&origin=${window.location.origin}&autoplay=1`;
+            bottomVideoContainer.innerHTML = '';
+            bottomVideoContainer.appendChild(currentIframe);
+            bottomTitleEl.textContent = song.name;
+            currentPlayingId = parseInt(song.token_id, 10);
+            bottomPlayer.classList.remove('hidden');
+            isPlaying = true;
+            playBtn.querySelector('.material-icons').textContent = 'pause';
+        } catch (err) {
+            console.error('Error loading song by ID', err);
+        }
     }
 
     function getYouTubeVideoId(url) {
@@ -543,14 +625,26 @@ import * as etherscanApi from './api/etherscan.js';
             // video
             const videoContainer = modalContent.querySelector('.video-container');
             videoContainer.innerHTML = '';
+            if (currentIframe && bottomVideoContainer.contains(currentIframe)) {
+                videoContainer.appendChild(currentIframe);
+                bottomPlayer.classList.add('hidden');
+            }
             if (song.youtube_url) {
                 const vid = getYouTubeVideoId(song.youtube_url);
                 if (vid) {
-                    const iframe = document.createElement('iframe');
-                    iframe.src = `https://www.youtube.com/embed/${vid}`;
-                    iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
-                    iframe.allowFullscreen = true;
-                    videoContainer.appendChild(iframe);
+                    if (!currentIframe) {
+                        currentIframe = document.createElement('iframe');
+                        currentIframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+                        currentIframe.allowFullscreen = true;
+                    }
+                    currentIframe.src = `https://www.youtube.com/embed/${vid}?enablejsapi=1&origin=${window.location.origin}`;
+                    if (currentIframe.parentElement !== videoContainer) {
+                        videoContainer.appendChild(currentIframe);
+                    }
+                    bottomTitleEl.textContent = song.name;
+                    currentPlayingId = parseInt(song.token_id, 10);
+                    isPlaying = false;
+                    playBtn.querySelector('.material-icons').textContent = 'play_arrow';
                 }
             }
 


### PR DESCRIPTION
## Summary
- add a fixed bottom-player element and styles
- create bottom-player controls in JS and move YouTube iframe between modal and player
- allow next/prev song loading and volume control

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*