### PR TITLE
Add persistent bottom player

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,6 +395,16 @@
         /* .controls-bar{transition:opacity 0.2s ease;} */
         .material-icons{font-size:24px;}
 
+        /* Bottom Player Styles */
+        .bottom-player{position:fixed;bottom:0;left:0;width:100%;background:#111;border-top:1px solid rgba(255,255,255,0.1);display:flex;align-items:center;padding:8px;box-sizing:border-box;z-index:3000;}
+        .bottom-player.hidden{display:none;}
+        .bottom-player .player-video{width:200px;height:112px;position:relative;flex-shrink:0;}
+        .bottom-player .player-video iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
+        .bottom-player .player-info{display:flex;align-items:center;flex:1;margin-left:10px;overflow:hidden;}
+        .bottom-player .player-title{flex:1;margin-right:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+        .bottom-player .player-controls{display:flex;align-items:center;gap:6px;}
+        #player-volume{width:100px;}
+
     </style>
 </head>
 <body>
@@ -469,6 +479,21 @@
         </div>
     </div>
 
+    <!-- Persistent Bottom Player -->
+    <div id="bottom-player" class="bottom-player hidden">
+        <div class="player-video"></div>
+        <div class="player-info">
+            <span class="player-title"></span>
+            <div class="player-controls">
+                <button id="player-prev" class="icon-button" title="Previous"><span class="material-icons">skip_previous</span></button>
+                <button id="player-play" class="icon-button" title="Play/Pause"><span class="material-icons">pause</span></button>
+                <button id="player-next" class="icon-button" title="Next"><span class="material-icons">skip_next</span></button>
+                <input id="player-volume" type="range" min="0" max="100" value="100" />
+            </div>
+        </div>
+    </div>
+
+    <script src="https://www.youtube.com/iframe_api"></script>
     <script type="module" src="src/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a fixed bottom-player element and styles
- create bottom-player controls in JS and move YouTube iframe between modal and player
- allow next/prev song loading and volume control
- keep playback active when moving the iframe

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*